### PR TITLE
feat: scaffold react admin dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+node_modules/
+dist/
+.env
+.DS_Store
+npm-debug.log*
+.vscode/
+.idea/
+coverage/
+*.log

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Abieo Admin</title>
+  </head>
+  <body class="bg-slate-50">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "projet-m2",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.64",
+    "@types/react-dom": "^18.2.20",
+    "@vitejs/plugin-react": "^4.2.1",
+    "autoprefixer": "^10.4.17",
+    "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-react-refresh": "^0.4.5",
+    "postcss": "^8.4.33",
+    "tailwindcss": "^3.4.3",
+    "typescript": "^5.4.2",
+    "vite": "^5.2.0",
+    "vitest": "^1.4.0"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,0 +1,15 @@
+import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
+import AppRoutes from './routes';
+
+const App = () => {
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route path="/*" element={<AppRoutes />} />
+        <Route path="*" element={<Navigate to="/admin" replace />} />
+      </Routes>
+    </BrowserRouter>
+  );
+};
+
+export default App;

--- a/src/components/DashboardCard.tsx
+++ b/src/components/DashboardCard.tsx
@@ -1,0 +1,29 @@
+import type { ReactNode } from 'react';
+
+interface DashboardCardProps {
+  icon: ReactNode;
+  title: string;
+  value: number | string;
+  description: string;
+  accentColor?: string;
+}
+
+const DashboardCard = ({ icon, title, value, description, accentColor = '#6C5DD3' }: DashboardCardProps) => {
+  return (
+    <article className="flex flex-1 min-w-[220px] rounded-2xl border border-slate-100 bg-white p-5 shadow-sm transition-transform hover:-translate-y-1">
+      <div
+        className="mr-4 flex h-12 w-12 items-center justify-center rounded-xl"
+        style={{ backgroundColor: `${accentColor}1a`, color: accentColor }}
+      >
+        {icon}
+      </div>
+      <div className="flex flex-col">
+        <span className="text-sm font-medium text-slate-500">{title}</span>
+        <span className="mt-1 text-2xl font-semibold text-slate-900">{value}</span>
+        <span className="text-xs text-slate-400">{description}</span>
+      </div>
+    </article>
+  );
+};
+
+export default DashboardCard;

--- a/src/components/QuickActionButton.tsx
+++ b/src/components/QuickActionButton.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from 'react';
+
+interface QuickActionButtonProps {
+  icon: ReactNode;
+  label: string;
+  description: string;
+  onClick?: () => void;
+}
+
+const QuickActionButton = ({ icon, label, description, onClick }: QuickActionButtonProps) => {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex flex-1 min-w-[220px] items-start gap-3 rounded-2xl border border-dashed border-primary-light bg-white p-5 text-left transition hover:border-primary hover:shadow-lg"
+    >
+      <span className="flex h-12 w-12 items-center justify-center rounded-xl bg-primary-light text-primary">{icon}</span>
+      <span className="flex flex-col">
+        <span className="text-base font-semibold text-slate-900">{label}</span>
+        <span className="text-sm text-slate-500">{description}</span>
+      </span>
+    </button>
+  );
+};
+
+export default QuickActionButton;

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,18 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color: #1f2937;
+  font-family: 'Poppins', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+body {
+  margin: 0;
+  background-color: #f7f8fc;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './app';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -1,0 +1,171 @@
+import { useMemo } from 'react';
+import DashboardCard from '../components/DashboardCard';
+import QuickActionButton from '../components/QuickActionButton';
+import AdminLayout from '../templates/AdminLayout';
+
+const IconStack = () => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+    <path d="M12 2L3 6.5L12 11L21 6.5L12 2Z" opacity="0.8" />
+    <path d="M3 12L12 16.5L21 12" opacity="0.5" />
+    <path d="M3 17.5L12 22L21 17.5" opacity="0.2" />
+  </svg>
+);
+
+const IconModule = () => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+    <rect x="3" y="3" width="7" height="7" rx="2" />
+    <rect x="14" y="3" width="7" height="7" rx="2" opacity="0.6" />
+    <rect x="3" y="14" width="7" height="7" rx="2" opacity="0.4" />
+    <rect x="14" y="14" width="7" height="7" rx="2" opacity="0.2" />
+  </svg>
+);
+
+const IconUsers = () => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+    <path d="M12 12C14.7614 12 17 9.76142 17 7C17 4.23858 14.7614 2 12 2C9.23858 2 7 4.23858 7 7C7 9.76142 9.23858 12 12 12Z" />
+    <path d="M4 22C4 17.5817 7.58172 14 12 14C16.4183 14 20 17.5817 20 22" opacity="0.6" />
+  </svg>
+);
+
+const IconBadge = () => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+    <path d="M12 2L15.09 8.26L22 9.27L17 14.14L18.18 21.02L12 17.77L5.82 21.02L7 14.14L2 9.27L8.91 8.26L12 2Z" />
+  </svg>
+);
+
+const IconPlus = () => (
+  <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path
+      d="M10 4.16669V15.8334"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M4.16663 10H15.8333"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+const AdminPage = () => {
+  const stats = useMemo(
+    () => [
+      {
+        title: 'Programmes',
+        value: 12,
+        description: 'Programmes actifs dans la plateforme',
+        accent: '#6C5DD3',
+        icon: <IconStack />,
+      },
+      {
+        title: 'Modules',
+        value: 28,
+        description: 'Modules disponibles pour les apprenants',
+        accent: '#56CCF2',
+        icon: <IconModule />,
+      },
+      {
+        title: 'Apprenants',
+        value: 97,
+        description: 'Apprenants inscrits cette semaine',
+        accent: '#27AE60',
+        icon: <IconUsers />,
+      },
+      {
+        title: 'Badges',
+        value: 7,
+        description: 'Badges certifiants actifs',
+        accent: '#F2994A',
+        icon: <IconBadge />,
+      },
+    ],
+    [],
+  );
+
+  const quickActions = useMemo(
+    () => [
+      {
+        label: 'Nouveau Programme',
+        description: 'Créer un nouveau parcours de formation',
+        icon: <IconPlus />,
+      },
+      {
+        label: 'Nouveau Module',
+        description: 'Ajouter un module de formation',
+        icon: <IconPlus />,
+      },
+      {
+        label: 'Nouvel Apprenant',
+        description: 'Inscrire un nouvel apprenant',
+        icon: <IconPlus />,
+      },
+      {
+        label: 'Nouveau Badge',
+        description: 'Créer un badge de reconnaissance',
+        icon: <IconPlus />,
+      },
+    ],
+    [],
+  );
+
+  return (
+    <AdminLayout>
+      <section className="flex flex-col gap-8">
+        <header>
+          <p className="text-sm font-medium uppercase tracking-wide text-primary">Aperçu</p>
+          <h1 className="mt-2 text-3xl font-semibold text-slate-900">Panel Administrateur</h1>
+          <p className="mt-2 max-w-2xl text-sm text-slate-500">
+            Gestion centralisée de La Ruche Académie. Visualisez les indicateurs clés et préparez les actions à réaliser pour
+            vos apprenants, formateurs et contenus.
+          </p>
+        </header>
+
+        <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          {stats.map((item) => (
+            <DashboardCard
+              key={item.title}
+              icon={item.icon}
+              title={item.title}
+              value={item.value}
+              description={item.description}
+              accentColor={item.accent}
+            />
+          ))}
+        </section>
+
+        <section className="flex flex-col gap-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <h2 className="text-xl font-semibold text-slate-900">Actions rapides</h2>
+              <p className="text-sm text-slate-500">Créez du contenu ou gérez les apprenants en un clic.</p>
+            </div>
+            <button
+              type="button"
+              className="rounded-full border border-slate-200 bg-white px-5 py-2 text-sm font-medium text-slate-600 shadow-sm transition hover:border-primary hover:text-primary"
+            >
+              Historique
+            </button>
+          </div>
+          <div className="flex flex-wrap gap-4">
+            {quickActions.map((action) => (
+              <QuickActionButton
+                key={action.label}
+                icon={action.icon}
+                label={action.label}
+                description={action.description}
+                onClick={() => console.log(`${action.label} clicked`)}
+              />
+            ))}
+          </div>
+        </section>
+      </section>
+    </AdminLayout>
+  );
+};
+
+export default AdminPage;

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,0 +1,13 @@
+import { Navigate, Route, Routes } from 'react-router-dom';
+import AdminPage from '../pages/AdminPage';
+
+const AppRoutes = () => {
+  return (
+    <Routes>
+      <Route path="admin" element={<AdminPage />} />
+      <Route path="" element={<Navigate to="admin" replace />} />
+    </Routes>
+  );
+};
+
+export default AppRoutes;

--- a/src/templates/AdminLayout.tsx
+++ b/src/templates/AdminLayout.tsx
@@ -1,0 +1,36 @@
+import type { PropsWithChildren } from 'react';
+
+const AdminLayout = ({ children }: PropsWithChildren) => {
+  return (
+    <div className="min-h-screen bg-slate-50">
+      <header className="border-b border-slate-200 bg-white">
+        <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
+          <div className="flex items-center gap-3">
+            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-primary text-white font-semibold">A</div>
+            <div className="flex flex-col">
+              <span className="text-lg font-semibold text-slate-900">Abieo Admin</span>
+              <span className="text-sm text-slate-500">Panel Administrateur</span>
+            </div>
+          </div>
+          <nav className="flex items-center gap-6 text-sm font-medium text-slate-500">
+            <a className="rounded-full bg-primary-light px-4 py-2 text-primary" href="#">Apprenant</a>
+            <a className="hover:text-primary" href="#">Formateur</a>
+            <a className="hover:text-primary" href="#">Admin</a>
+          </nav>
+          <div className="flex items-center gap-3">
+            <div className="text-right">
+              <p className="text-sm font-semibold text-slate-900">Jean Administrateur</p>
+              <p className="text-xs text-slate-500">Administrateur</p>
+            </div>
+            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-gradient-to-br from-primary to-primary-dark text-white font-semibold">
+              JA
+            </div>
+          </div>
+        </div>
+      </header>
+      <main className="mx-auto max-w-6xl px-6 py-10">{children}</main>
+    </div>
+  );
+};
+
+export default AdminLayout;

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -1,0 +1,10 @@
+export const palette = {
+  primary: '#6C5DD3',
+  primaryLight: '#E4E0FF',
+  primaryDark: '#4C3FB1',
+  warning: '#F2994A',
+  info: '#56CCF2',
+  success: '#27AE60',
+};
+
+export type PaletteKey = keyof typeof palette;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,22 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        primary: {
+          DEFAULT: '#6C5DD3',
+          light: '#E4E0FF',
+          dark: '#4C3FB1',
+        },
+        accent: '#F2994A',
+        info: '#56CCF2',
+        success: '#27AE60',
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["vitest/globals", "vite/client"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- scaffold a Vite + React + TypeScript frontend aligned with the agreed folder structure
- implement the admin layout, dashboard cards, and quick action buttons for the administrator panel
- configure Tailwind CSS theme extensions and routing entrypoints for the admin page

## Testing
- `npm install` *(fails: 403 Forbidden when reaching registry.npmjs.org in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d586acfcd88330aa5e5a1c7fb8f72c