### PR TITLE
Add formateur dashboard page

### DIFF
--- a/src/components/UpcomingCourseCard.tsx
+++ b/src/components/UpcomingCourseCard.tsx
@@ -1,0 +1,64 @@
+interface UpcomingCourseCardProps {
+  title: string;
+  date: string;
+  time: string;
+  location: string;
+  participants: number;
+  accentColor?: string;
+}
+
+const UpcomingCourseCard = ({
+  title,
+  date,
+  time,
+  location,
+  participants,
+  accentColor = '#F59E0B',
+}: UpcomingCourseCardProps) => {
+  return (
+    <article className="relative overflow-hidden rounded-2xl border border-amber-100 bg-white/80 p-5 shadow-sm transition hover:-translate-y-1 hover:shadow-md">
+      <span className="absolute inset-y-0 left-0 w-1" style={{ backgroundColor: accentColor }} />
+      <div className="pl-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide text-amber-500">{date}</p>
+            <h3 className="mt-1 text-lg font-semibold text-slate-900">{title}</h3>
+          </div>
+          <span className="rounded-full bg-amber-50 px-3 py-1 text-xs font-semibold text-amber-600">
+            {participants} apprenants
+          </span>
+        </div>
+        <div className="mt-4 flex flex-wrap items-center gap-4 text-sm text-slate-500">
+          <span className="flex items-center gap-2">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path
+                d="M12 7v5l3 3"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+              <circle cx="12" cy="12" r="9" stroke="currentColor" strokeWidth="1.5" />
+            </svg>
+            {time}
+          </span>
+          <span className="flex items-center gap-2">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path
+                d="M12 21s7-5.686 7-11a7 7 0 0 0-14 0c0 5.314 7 11 7 11Z"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+              <circle cx="12" cy="10" r="2.5" stroke="currentColor" strokeWidth="1.5" />
+            </svg>
+            {location}
+          </span>
+        </div>
+      </div>
+    </article>
+  );
+};
+
+export default UpcomingCourseCard;

--- a/src/pages/FormateurPage.tsx
+++ b/src/pages/FormateurPage.tsx
@@ -1,0 +1,284 @@
+import { useMemo } from 'react';
+import AdminNavigationTabs from '../components/AdminNavigationTabs';
+import DashboardCard from '../components/DashboardCard';
+import QuickActionButton from '../components/QuickActionButton';
+import UpcomingCourseCard from '../components/UpcomingCourseCard';
+import FormateurLayout from '../templates/FormateurLayout';
+
+const IconOverview = () => (
+  <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path
+      d="M10 3.333C5.833 3.333 2.275 6.108 1 10c1.275 3.892 4.833 6.667 9 6.667s7.725-2.775 9-6.667c-1.275-3.892-4.833-6.667-9-6.667Z"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M10 6.667c-1.842 0-3.333 1.492-3.333 3.333"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+const IconBook = () => (
+  <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path
+      d="M3.333 4.167A1.667 1.667 0 0 1 5 2.5h9.167a1.667 1.667 0 0 1 1.666 1.667v11.666A1.667 1.667 0 0 0 14.167 17.5H5A1.667 1.667 0 0 0 3.333 15.833V4.167Z"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path d="M3.333 6.667H16.667" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
+    <path d="M7.5 10h5" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+);
+
+const IconCalendar = () => (
+  <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <rect
+      x="2.5"
+      y="3.333"
+      width="15"
+      height="14.167"
+      rx="2"
+      stroke="currentColor"
+      strokeWidth="1.6"
+    />
+    <path d="M2.5 7.5h15" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+    <path d="M6.667 2.5v2.5" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+    <path d="M13.333 2.5v2.5" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+  </svg>
+);
+
+const IconNotes = () => (
+  <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path
+      d="M5 2.5h7.5L15 5v10a2.5 2.5 0 0 1-2.5 2.5H5A2.5 2.5 0 0 1 2.5 15V5A2.5 2.5 0 0 1 5 2.5Z"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path d="M7.5 10H12.5" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+    <path d="M7.5 13.333h2.5" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+  </svg>
+);
+
+const IconUsers = () => (
+  <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <circle cx="8.333" cy="7.5" r="2.5" stroke="currentColor" strokeWidth="1.6" />
+    <path
+      d="M12.5 17.5c0-2.301-1.866-4.167-4.167-4.167C6.033 13.333 4.167 15.199 4.167 17.5"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M13.75 8.75a2.083 2.083 0 1 0 0-4.166"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M15.833 17.5a3.333 3.333 0 0 0-3.333-3.333"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+const IconStar = () => (
+  <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path
+      d="M10 2.5 11.944 7l4.389.333-3.333 3 1 4.5L10 12.917 6 14.833l1-4.5-3.333-3L8.056 7 10 2.5Z"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+const IconPlus = () => (
+  <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M10 4.167v11.667" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+    <path d="M4.167 10h11.666" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+);
+
+const IconEdit = () => (
+  <svg width="18" height="18" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path
+      d="m11.667 4.167 4.166 4.166-8.333 8.334H3.333v-4.167l8.334-8.333Z"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path d="m10 5.833 4.167 4.167" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+);
+
+const IconClipboard = () => (
+  <svg width="18" height="18" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path
+      d="M13.333 3.333h.834a1.667 1.667 0 0 1 1.666 1.667v10a1.667 1.667 0 0 1-1.666 1.667H5.833A1.667 1.667 0 0 1 4.167 15V5A1.667 1.667 0 0 1 5.833 3.333h.834"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <rect x="7.5" y="2.5" width="5" height="2.5" rx="1.25" stroke="currentColor" strokeWidth="1.6" />
+    <path d="M7.5 9.167h5" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+    <path d="M7.5 12.5h3.333" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+  </svg>
+);
+
+const FormateurPage = () => {
+  const navigationTabs = useMemo(
+    () => [
+      { label: 'Aperçu', icon: <IconOverview />, active: true },
+      { label: 'Mes cours', icon: <IconBook /> },
+      { label: 'Notes', icon: <IconNotes /> },
+      { label: 'Apprenants', icon: <IconUsers /> },
+    ],
+    [],
+  );
+
+  const stats = useMemo(
+    () => [
+      { title: 'Cours créés', value: 12, description: 'Cours publiés cette année', accent: '#F59E0B', icon: <IconBook /> },
+      { title: 'Mes cours', value: 5, description: 'Cours actifs dans votre planning', accent: '#F97316', icon: <IconCalendar /> },
+      { title: 'Cours à venir', value: 3, description: 'Sessions prévues cette semaine', accent: '#FBBF24', icon: <IconCalendar /> },
+      { title: 'Notes attribuées', value: 48, description: 'Copies évaluées ce mois-ci', accent: '#FDBA74', icon: <IconStar /> },
+      { title: 'Apprenants', value: 87, description: 'Apprenants suivis actuellement', accent: '#FB923C', icon: <IconUsers /> },
+    ],
+    [],
+  );
+
+  const quickActions = useMemo(
+    () => [
+      { label: 'Créer un cours', description: 'Ajoutez un nouveau module à votre catalogue', icon: <IconPlus /> },
+      { label: 'Gérer les notes', description: 'Attribuez ou modifiez les notes des apprenants', icon: <IconClipboard /> },
+      { label: 'Mettre à jour un cours', description: 'Actualisez le contenu d’une session', icon: <IconEdit /> },
+    ],
+    [],
+  );
+
+  const upcomingCourses = useMemo(
+    () => [
+      {
+        title: 'Atelier UX Design',
+        date: 'Mercredi 10 Avril',
+        time: '09:00 - 11:30',
+        location: 'Salle B - Campus Lyon',
+        participants: 18,
+        accentColor: '#F59E0B',
+      },
+      {
+        title: 'Sprint Agile Avancé',
+        date: 'Jeudi 11 Avril',
+        time: '14:00 - 17:00',
+        location: 'Visio Microsoft Teams',
+        participants: 22,
+        accentColor: '#F97316',
+      },
+      {
+        title: 'Coaching individuel',
+        date: 'Vendredi 12 Avril',
+        time: '10:00 - 11:00',
+        location: 'Bureau 3.2',
+        participants: 1,
+        accentColor: '#FBBF24',
+      },
+    ],
+    [],
+  );
+
+  return (
+    <FormateurLayout>
+      <section className="flex flex-col gap-8">
+        <header className="rounded-3xl bg-white/80 p-8 shadow-sm backdrop-blur">
+          <p className="text-sm font-semibold uppercase tracking-wide text-amber-500">Bonjour Sophie</p>
+          <h1 className="mt-2 text-3xl font-semibold text-slate-900">Espace Formateur</h1>
+          <p className="mt-2 max-w-2xl text-sm text-slate-600">
+            Retrouvez vos indicateurs clés, vos prochaines sessions et accédez rapidement aux actions les plus fréquentes pour vos
+            apprenants.
+          </p>
+        </header>
+
+        <AdminNavigationTabs items={navigationTabs} />
+
+        <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
+          {stats.map((item) => (
+            <DashboardCard
+              key={item.title}
+              icon={item.icon}
+              title={item.title}
+              value={item.value}
+              description={item.description}
+              accentColor={item.accent}
+            />
+          ))}
+        </section>
+
+        <section className="flex flex-col gap-4">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <h2 className="text-xl font-semibold text-slate-900">Actions rapides</h2>
+              <p className="text-sm text-slate-500">Gagnez du temps sur les tâches essentielles de votre quotidien.</p>
+            </div>
+            <button
+              type="button"
+              className="rounded-full border border-amber-200 bg-white px-5 py-2 text-sm font-medium text-amber-600 shadow-sm transition hover:border-amber-300 hover:text-amber-700"
+            >
+              Historique des actions
+            </button>
+          </div>
+          <div className="flex flex-wrap gap-4">
+            {quickActions.map((action) => (
+              <QuickActionButton
+                key={action.label}
+                icon={action.icon}
+                label={action.label}
+                description={action.description}
+                onClick={() => console.log(`${action.label} clicked`)}
+              />
+            ))}
+          </div>
+        </section>
+
+        <section className="flex flex-col gap-4">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <h2 className="text-xl font-semibold text-slate-900">Prochains cours</h2>
+              <p className="text-sm text-slate-500">Gardez une longueur d’avance sur vos prochaines interventions.</p>
+            </div>
+            <button
+              type="button"
+              className="rounded-full bg-amber-500 px-5 py-2 text-sm font-semibold text-white shadow transition hover:bg-amber-600"
+            >
+              Voir le planning complet
+            </button>
+          </div>
+          <div className="grid gap-4 lg:grid-cols-3">
+            {upcomingCourses.map((course) => (
+              <UpcomingCourseCard key={course.title} {...course} />
+            ))}
+          </div>
+        </section>
+      </section>
+    </FormateurLayout>
+  );
+};
+
+export default FormateurPage;

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,11 +1,13 @@
 import { Navigate, Route, Routes } from 'react-router-dom';
 import AdminPage from '../pages/AdminPage';
+import FormateurPage from '../pages/FormateurPage';
 
 const AppRoutes = () => {
   return (
     <Routes>
       <Route path="admin" element={<AdminPage />} />
-      <Route path="" element={<Navigate to="admin" replace />} />
+      <Route path="formateur" element={<FormateurPage />} />
+      <Route path="" element={<Navigate to="formateur" replace />} />
     </Routes>
   );
 };

--- a/src/templates/AdminLayout.tsx
+++ b/src/templates/AdminLayout.tsx
@@ -1,4 +1,5 @@
 import type { PropsWithChildren } from 'react';
+import { Link } from 'react-router-dom';
 
 const AdminLayout = ({ children }: PropsWithChildren) => {
   return (
@@ -13,9 +14,15 @@ const AdminLayout = ({ children }: PropsWithChildren) => {
             </div>
           </div>
           <nav className="flex items-center gap-6 text-sm font-medium text-slate-500">
-            <a className="rounded-full bg-primary-light px-4 py-2 text-primary" href="#">Apprenant</a>
-            <a className="hover:text-primary" href="#">Formateur</a>
-            <a className="hover:text-primary" href="#">Admin</a>
+            <Link className="rounded-full px-4 py-2 transition hover:text-primary" to="#">
+              Apprenant
+            </Link>
+            <Link className="hover:text-primary" to="/formateur">
+              Formateur
+            </Link>
+            <Link className="rounded-full bg-primary-light px-4 py-2 text-primary" to="/admin">
+              Admin
+            </Link>
           </nav>
           <div className="flex items-center gap-3">
             <div className="text-right">

--- a/src/templates/FormateurLayout.tsx
+++ b/src/templates/FormateurLayout.tsx
@@ -1,0 +1,72 @@
+import type { PropsWithChildren } from 'react';
+import { Link } from 'react-router-dom';
+
+const FormateurLayout = ({ children }: PropsWithChildren) => {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-amber-50 via-orange-50 to-white">
+      <header className="border-b border-amber-100 bg-white/80 backdrop-blur">
+        <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
+          <div className="flex items-center gap-3">
+            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-primary text-white text-lg font-semibold">
+              A
+            </div>
+            <div className="flex flex-col">
+              <span className="text-lg font-semibold text-slate-900">Abieo</span>
+              <span className="text-sm font-medium text-amber-600">Espace Formateur</span>
+            </div>
+          </div>
+
+          <nav className="hidden items-center gap-3 text-sm font-medium text-slate-500 md:flex">
+            <Link
+              to="/apprenant"
+              className="rounded-full px-4 py-2 transition hover:text-primary"
+            >
+              Apprenant
+            </Link>
+            <Link
+              to="/formateur"
+              className="rounded-full bg-primary px-4 py-2 text-white shadow transition hover:shadow-md"
+            >
+              Formateur
+            </Link>
+            <Link
+              to="/admin"
+              className="rounded-full px-4 py-2 transition hover:text-primary"
+            >
+              Admin
+            </Link>
+          </nav>
+
+          <div className="flex items-center gap-3">
+            <button
+              type="button"
+              className="flex h-10 w-10 items-center justify-center rounded-full border border-amber-100 bg-white text-amber-500 shadow-sm transition hover:text-amber-600"
+              aria-label="Notifications"
+            >
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path
+                  d="M12 22a2 2 0 0 0 2-2H10a2 2 0 0 0 2 2Zm8-6v-5a8 8 0 0 0-16 0v5l-2 2v1h20v-1l-2-2Z"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </button>
+            <div className="text-right">
+              <p className="text-sm font-semibold text-slate-900">Sophie Martin</p>
+              <p className="text-xs text-amber-600">Formatrice</p>
+            </div>
+            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-gradient-to-br from-amber-400 to-orange-500 text-sm font-semibold text-white">
+              SM
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-6xl px-6 py-10">{children}</main>
+    </div>
+  );
+};
+
+export default FormateurLayout;


### PR DESCRIPTION
## Summary
- add a dedicated layout and dashboard page for the formateur space
- introduce reusable upcoming course card component and supporting data
- update routing and admin navigation to link to the new view

## Testing
- `npm run lint` *(fails: missing ESLint configuration in project)*

------
https://chatgpt.com/codex/tasks/task_b_68d59562b0a08330b9452f8c8ef94ebc