### PR TITLE
Implement interactive Mes cours tab on Formateur page

### DIFF
--- a/src/pages/FormateurPage.tsx
+++ b/src/pages/FormateurPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import AdminNavigationTabs from '../components/AdminNavigationTabs';
 import DashboardCard from '../components/DashboardCard';
 import QuickActionButton from '../components/QuickActionButton';
@@ -144,15 +144,58 @@ const IconClipboard = () => (
 );
 
 const FormateurPage = () => {
+  const [activeTab, setActiveTab] = useState('Aperçu');
+
   const navigationTabs = useMemo(
     () => [
-      { label: 'Aperçu', icon: <IconOverview />, active: true },
-      { label: 'Mes cours', icon: <IconBook /> },
-      { label: 'Notes', icon: <IconNotes /> },
-      { label: 'Apprenants', icon: <IconUsers /> },
+      { label: 'Aperçu', icon: <IconOverview />, active: activeTab === 'Aperçu', onClick: () => setActiveTab('Aperçu') },
+      { label: 'Mes cours', icon: <IconBook />, active: activeTab === 'Mes cours', onClick: () => setActiveTab('Mes cours') },
+      { label: 'Notes', icon: <IconNotes />, active: activeTab === 'Notes', onClick: () => setActiveTab('Notes') },
+      {
+        label: 'Apprenants',
+        icon: <IconUsers />,
+        active: activeTab === 'Apprenants',
+        onClick: () => setActiveTab('Apprenants'),
+      },
     ],
-    [],
+    [activeTab],
   );
+
+  const headerContent = useMemo(() => {
+    if (activeTab === 'Mes cours') {
+      return {
+        eyebrow: 'Mes cours',
+        title: 'Gestion de vos sessions',
+        description:
+          'Consultez vos cours programmés, accédez à l’historique des sessions passées et préparez les prochaines animations.',
+      } as const;
+    }
+
+    if (activeTab === 'Notes') {
+      return {
+        eyebrow: 'Notes',
+        title: 'Suivi des évaluations',
+        description:
+          'Retrouvez les copies corrigées, assurez le suivi des notes attribuées et identifiez les apprenants à relancer.',
+      } as const;
+    }
+
+    if (activeTab === 'Apprenants') {
+      return {
+        eyebrow: 'Apprenants',
+        title: 'Accompagnement des apprenants',
+        description:
+          'Analysez la progression des apprenants, organisez des points individuels et planifiez vos actions de coaching.',
+      } as const;
+    }
+
+    return {
+      eyebrow: 'Bonjour Sophie',
+      title: 'Espace Formateur',
+      description:
+        'Retrouvez vos indicateurs clés, vos prochaines sessions et accédez rapidement aux actions les plus fréquentes pour vos apprenants.',
+    } as const;
+  }, [activeTab]);
 
   const stats = useMemo(
     () => [
@@ -204,78 +247,296 @@ const FormateurPage = () => {
     [],
   );
 
+  const myCourses = useMemo(
+    () => ({
+      upcoming: [] as Array<{ title: string; date: string; time: string; location: string; participants: number }>,
+      past: [
+        {
+          title: 'Introduction aux composants React',
+          module: 'Sous bloc React',
+          nextSession: {
+            label: 'Premier cours : Les composants React',
+            date: '15/03/2024',
+            time: '10:00 - 12:00',
+          },
+          description:
+            'Introduction aux composants React, props et JSX. Création de premiers composants fonctionnels.',
+          location: 'Salle de formation A',
+          participants: 13,
+          resources: 'Slides de formation A',
+        },
+        {
+          title: 'Les Hooks React',
+          module: 'Sous bloc React',
+          nextSession: {
+            label: 'Premier cours : Les Hooks React',
+            date: '18/03/2024',
+            time: '09:30 - 11:30',
+          },
+          description: 'Comprendre useState et useEffect pour gérer l’état et les effets de bord dans vos applications.',
+          location: 'Salle de formation B',
+          participants: 16,
+          resources: 'Supports interactifs & quiz de révision',
+        },
+      ],
+    }),
+    [],
+  );
+
   return (
     <FormateurLayout>
       <section className="flex flex-col gap-8">
         <header className="rounded-3xl bg-white/80 p-8 shadow-sm backdrop-blur">
-          <p className="text-sm font-semibold uppercase tracking-wide text-amber-500">Bonjour Sophie</p>
-          <h1 className="mt-2 text-3xl font-semibold text-slate-900">Espace Formateur</h1>
-          <p className="mt-2 max-w-2xl text-sm text-slate-600">
-            Retrouvez vos indicateurs clés, vos prochaines sessions et accédez rapidement aux actions les plus fréquentes pour vos
-            apprenants.
-          </p>
+          <p className="text-sm font-semibold uppercase tracking-wide text-amber-500">{headerContent.eyebrow}</p>
+          <h1 className="mt-2 text-3xl font-semibold text-slate-900">{headerContent.title}</h1>
+          <p className="mt-2 max-w-2xl text-sm text-slate-600">{headerContent.description}</p>
         </header>
 
         <AdminNavigationTabs items={navigationTabs} />
 
-        <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
-          {stats.map((item) => (
-            <DashboardCard
-              key={item.title}
-              icon={item.icon}
-              title={item.title}
-              value={item.value}
-              description={item.description}
-              accentColor={item.accent}
-            />
-          ))}
-        </section>
+        {activeTab === 'Aperçu' ? (
+          <>
+            <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
+              {stats.map((item) => (
+                <DashboardCard
+                  key={item.title}
+                  icon={item.icon}
+                  title={item.title}
+                  value={item.value}
+                  description={item.description}
+                  accentColor={item.accent}
+                />
+              ))}
+            </section>
 
-        <section className="flex flex-col gap-4">
-          <div className="flex flex-wrap items-center justify-between gap-3">
-            <div>
-              <h2 className="text-xl font-semibold text-slate-900">Actions rapides</h2>
-              <p className="text-sm text-slate-500">Gagnez du temps sur les tâches essentielles de votre quotidien.</p>
-            </div>
-            <button
-              type="button"
-              className="rounded-full border border-amber-200 bg-white px-5 py-2 text-sm font-medium text-amber-600 shadow-sm transition hover:border-amber-300 hover:text-amber-700"
-            >
-              Historique des actions
-            </button>
-          </div>
-          <div className="flex flex-wrap gap-4">
-            {quickActions.map((action) => (
-              <QuickActionButton
-                key={action.label}
-                icon={action.icon}
-                label={action.label}
-                description={action.description}
-                onClick={() => console.log(`${action.label} clicked`)}
-              />
-            ))}
-          </div>
-        </section>
+            <section className="flex flex-col gap-4">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <h2 className="text-xl font-semibold text-slate-900">Actions rapides</h2>
+                  <p className="text-sm text-slate-500">Gagnez du temps sur les tâches essentielles de votre quotidien.</p>
+                </div>
+                <button
+                  type="button"
+                  className="rounded-full border border-amber-200 bg-white px-5 py-2 text-sm font-medium text-amber-600 shadow-sm transition hover:border-amber-300 hover:text-amber-700"
+                >
+                  Historique des actions
+                </button>
+              </div>
+              <div className="flex flex-wrap gap-4">
+                {quickActions.map((action) => (
+                  <QuickActionButton
+                    key={action.label}
+                    icon={action.icon}
+                    label={action.label}
+                    description={action.description}
+                    onClick={() => console.log(`${action.label} clicked`)}
+                  />
+                ))}
+              </div>
+            </section>
 
-        <section className="flex flex-col gap-4">
-          <div className="flex flex-wrap items-center justify-between gap-3">
-            <div>
-              <h2 className="text-xl font-semibold text-slate-900">Prochains cours</h2>
-              <p className="text-sm text-slate-500">Gardez une longueur d’avance sur vos prochaines interventions.</p>
+            <section className="flex flex-col gap-4">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <h2 className="text-xl font-semibold text-slate-900">Prochains cours</h2>
+                  <p className="text-sm text-slate-500">Gardez une longueur d’avance sur vos prochaines interventions.</p>
+                </div>
+                <button
+                  type="button"
+                  className="rounded-full bg-amber-500 px-5 py-2 text-sm font-semibold text-white shadow transition hover:bg-amber-600"
+                >
+                  Voir le planning complet
+                </button>
+              </div>
+              <div className="grid gap-4 lg:grid-cols-3">
+                {upcomingCourses.map((course) => (
+                  <UpcomingCourseCard key={course.title} {...course} />
+                ))}
+              </div>
+            </section>
+          </>
+        ) : null}
+
+        {activeTab === 'Mes cours' ? (
+          <section className="flex flex-col gap-8">
+            <div className="flex flex-col gap-4">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <h2 className="text-xl font-semibold text-slate-900">Cours à venir</h2>
+                  <p className="text-sm text-slate-500">Visualisez les prochaines sessions prévues dans votre agenda.</p>
+                </div>
+                <button
+                  type="button"
+                  className="rounded-full border border-amber-200 bg-white px-5 py-2 text-sm font-medium text-amber-600 shadow-sm transition hover:border-amber-300 hover:text-amber-700"
+                >
+                  Programmer un cours
+                </button>
+              </div>
+              {myCourses.upcoming.length > 0 ? (
+                <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                  {myCourses.upcoming.map((course) => (
+                    <article
+                      key={`${course.title}-${course.date}`}
+                      className="relative overflow-hidden rounded-3xl border border-amber-100 bg-white/80 p-6 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md"
+                    >
+                      <span className="absolute inset-y-0 left-0 w-1 rounded-full bg-amber-400" />
+                      <div className="pl-4">
+                        <h3 className="text-lg font-semibold text-slate-900">{course.title}</h3>
+                        <p className="mt-1 text-sm text-slate-500">{course.date}</p>
+                        <div className="mt-4 flex flex-wrap gap-4 text-sm text-slate-500">
+                          <span className="flex items-center gap-2">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                              <path d="M3 5h18" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+                              <rect x="4" y="5" width="16" height="15" rx="2" stroke="currentColor" strokeWidth="1.5" />
+                              <path d="M8 3v4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+                              <path d="M16 3v4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+                            </svg>
+                            {course.time}
+                          </span>
+                          <span className="flex items-center gap-2">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                              <path
+                                d="M12 21s7-5.686 7-11a7 7 0 0 0-14 0c0 5.314 7 11 7 11Z"
+                                stroke="currentColor"
+                                strokeWidth="1.5"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                              />
+                              <circle cx="12" cy="10" r="2.5" stroke="currentColor" strokeWidth="1.5" />
+                            </svg>
+                            {course.location}
+                          </span>
+                          <span className="flex items-center gap-2">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                              <path
+                                d="M16 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"
+                                stroke="currentColor"
+                                strokeWidth="1.5"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                              />
+                              <circle cx="12" cy="7" r="4" stroke="currentColor" strokeWidth="1.5" />
+                            </svg>
+                            {course.participants} apprenants
+                          </span>
+                        </div>
+                      </div>
+                    </article>
+                  ))}
+                </div>
+              ) : (
+                <div className="flex flex-col items-center justify-center gap-4 rounded-3xl border border-dashed border-amber-200 bg-white/70 p-10 text-center">
+                  <span className="flex h-14 w-14 items-center justify-center rounded-full bg-amber-50 text-amber-500">
+                    <IconCalendar />
+                  </span>
+                  <div>
+                    <p className="text-base font-semibold text-slate-900">Aucun cours programmé</p>
+                    <p className="mt-1 text-sm text-slate-500">Ajoutez une nouvelle session ou consultez vos cours passés.</p>
+                  </div>
+                  <button
+                    type="button"
+                    className="rounded-full bg-amber-500 px-5 py-2 text-sm font-semibold text-white shadow transition hover:bg-amber-600"
+                  >
+                    Créer une session
+                  </button>
+                </div>
+              )}
             </div>
-            <button
-              type="button"
-              className="rounded-full bg-amber-500 px-5 py-2 text-sm font-semibold text-white shadow transition hover:bg-amber-600"
-            >
-              Voir le planning complet
-            </button>
-          </div>
-          <div className="grid gap-4 lg:grid-cols-3">
-            {upcomingCourses.map((course) => (
-              <UpcomingCourseCard key={course.title} {...course} />
-            ))}
-          </div>
-        </section>
+
+            <div className="flex flex-col gap-4">
+              <div>
+                <h2 className="text-xl font-semibold text-slate-900">Cours passés</h2>
+                <p className="text-sm text-slate-500">Retrouvez les détails de vos dernières interventions.</p>
+              </div>
+              <div className="flex flex-col gap-4">
+                {myCourses.past.map((course) => (
+                  <article
+                    key={course.title}
+                    className="rounded-3xl border border-amber-100 bg-white/80 p-6 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md"
+                  >
+                    <div className="flex flex-wrap items-start justify-between gap-4">
+                      <div>
+                        <p className="text-xs font-semibold uppercase tracking-wide text-amber-500">{course.module}</p>
+                        <h3 className="mt-1 text-lg font-semibold text-slate-900">{course.title}</h3>
+                        <p className="mt-2 text-sm text-slate-500">{course.nextSession.label}</p>
+                      </div>
+                      <div className="flex flex-col items-end gap-2">
+                        <span className="rounded-full bg-amber-50 px-3 py-1 text-xs font-semibold text-amber-600">
+                          {course.participants} apprenants
+                        </span>
+                        <span className="flex items-center gap-2 text-xs text-slate-400">
+                          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                            <path
+                              d="M12 21s7-5.686 7-11a7 7 0 0 0-14 0c0 5.314 7 11 7 11Z"
+                              stroke="currentColor"
+                              strokeWidth="1.5"
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                            />
+                            <circle cx="12" cy="10" r="2.5" stroke="currentColor" strokeWidth="1.5" />
+                          </svg>
+                          {course.location}
+                        </span>
+                      </div>
+                    </div>
+                    <p className="mt-4 text-sm text-slate-600">{course.description}</p>
+                    <div className="mt-4 grid gap-4 text-sm text-slate-500 md:grid-cols-3">
+                      <span className="flex items-center gap-2">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                          <path
+                            d="M3 5h18"
+                            stroke="currentColor"
+                            strokeWidth="1.5"
+                            strokeLinecap="round"
+                          />
+                          <rect
+                            x="4"
+                            y="5"
+                            width="16"
+                            height="15"
+                            rx="2"
+                            stroke="currentColor"
+                            strokeWidth="1.5"
+                          />
+                          <path d="M8 3v4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+                          <path d="M16 3v4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+                        </svg>
+                        {course.nextSession.date}
+                      </span>
+                      <span className="flex items-center gap-2">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                          <path
+                            d="M12 7v5l3 3"
+                            stroke="currentColor"
+                            strokeWidth="1.5"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                          />
+                          <circle cx="12" cy="12" r="9" stroke="currentColor" strokeWidth="1.5" />
+                        </svg>
+                        {course.nextSession.time}
+                      </span>
+                      <span className="flex items-center gap-2">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                          <path
+                            d="M9 3h6l1 2h4v2h-1v11a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V7H4V5h4l1-2Z"
+                            stroke="currentColor"
+                            strokeWidth="1.5"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                          />
+                          <path d="M9 11h6" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+                          <path d="M9 15h6" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+                        </svg>
+                        {course.resources}
+                      </span>
+                    </div>
+                  </article>
+                ))}
+              </div>
+            </div>
+          </section>
+        ) : null}
       </section>
     </FormateurLayout>
   );


### PR DESCRIPTION
## Summary
- add tab state management to the formateur page navigation to toggle the "Mes cours" view
- update the page header to react to the selected tab and better explain each workspace
- build the "Mes cours" tab content with upcoming-course placeholders and detailed past course cards

## Testing
- npm run lint *(fails: ESLint configuration file missing in repository)*
- npm run test -- --run *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_b_68d5ab232a7883308cbde3da32344362