### PR TITLE
feat: add admin module creation modal

### DIFF
--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -1,5 +1,5 @@
 // Importation des hooks React et des composants nécessaires
-import { useMemo, useState } from 'react';
+import { FormEvent, useMemo, useState } from 'react';
 import AdminNavigationTabs from '../components/AdminNavigationTabs';
 import DashboardCard from '../components/DashboardCard';
 import QuickActionButton from '../components/QuickActionButton';
@@ -136,13 +136,51 @@ const IconEdit = () => (
 const AdminPage = () => {
   // État pour gérer l'onglet actif
   const [activeTab, setActiveTab] = useState('Aperçu');
+  const [isAddLearnerModalOpen, setIsAddLearnerModalOpen] = useState(false);
+  const [isAddModuleModalOpen, setIsAddModuleModalOpen] = useState(false);
+  const [newLearner, setNewLearner] = useState({
+    firstName: '',
+    lastName: '',
+    email: '',
+    modules: [] as string[],
+  });
+
+  const [newModule, setNewModule] = useState({
+    title: '',
+    programme: 'Aucun programme',
+    description: '',
+    category: '',
+    difficulty: 'Débutant',
+    duration: '',
+    prerequisites: '',
+    objectives: '',
+  });
+
+  type Learner = {
+    name: string;
+    handle: string;
+    email: string;
+    programme?: string;
+    modulesCompleted?: number;
+    totalModules?: number;
+    lastActivity?: string;
+    modulesToEnroll?: string[];
+  };
 
   // Configuration des onglets de navigation avec mémorisation pour optimiser les performances
   const navigationTabs = useMemo(
     () => [
       { label: 'Aperçu', icon: <IconOverview />, active: activeTab === 'Aperçu', onClick: () => setActiveTab('Aperçu') },
       { label: 'Programmes', icon: <IconStack />, active: activeTab === 'Programmes', onClick: () => setActiveTab('Programmes') },
-      { label: 'Modules', icon: <IconModule />, active: activeTab === 'Modules', onClick: () => setActiveTab('Modules') },
+      {
+        label: 'Modules',
+        icon: <IconModule />,
+        active: activeTab === 'Modules',
+        onClick: () => {
+          setActiveTab('Modules');
+          setIsAddModuleModalOpen(false);
+        },
+      },
       { label: 'Apprenants', icon: <IconUsers />, active: activeTab === 'Apprenants', onClick: () => setActiveTab('Apprenants') },
       { label: 'Badges', icon: <IconBookmarks />, active: activeTab === 'Badges', onClick: () => setActiveTab('Badges') },
     ],
@@ -209,12 +247,38 @@ const AdminPage = () => {
   // Configuration des boutons d'actions rapides
   const quickActions = useMemo(
     () => [
-      { label: 'Nouveau Programme', description: 'Créer un nouveau parcours de formation', icon: <IconPlus /> },
-      { label: 'Nouveau Module', description: 'Ajouter un module de formation', icon: <IconPlus /> },
-      { label: 'Nouvel Apprenant', description: 'Inscrire un nouvel apprenant', icon: <IconPlus /> },
-      { label: 'Nouveau Badge', description: 'Créer un badge de reconnaissance', icon: <IconPlus /> },
+      {
+        label: 'Nouveau Programme',
+        description: 'Créer un nouveau parcours de formation',
+        icon: <IconPlus />,
+        onClick: () => setActiveTab('Programmes'),
+      },
+      {
+        label: 'Nouveau Module',
+        description: 'Ajouter un module de formation',
+        icon: <IconPlus />,
+        onClick: () => {
+          setActiveTab('Modules');
+          setIsAddModuleModalOpen(true);
+        },
+      },
+      {
+        label: 'Nouvel Apprenant',
+        description: 'Inscrire un nouvel apprenant',
+        icon: <IconPlus />,
+        onClick: () => {
+          setActiveTab('Apprenants');
+          setIsAddLearnerModalOpen(true);
+        },
+      },
+      {
+        label: 'Nouveau Badge',
+        description: 'Créer un badge de reconnaissance',
+        icon: <IconPlus />,
+        onClick: () => setActiveTab('Badges'),
+      },
     ],
-    [],
+    [setActiveTab, setIsAddLearnerModalOpen, setIsAddModuleModalOpen],
   );
 
   // Données des programmes de formation
@@ -237,35 +301,43 @@ const AdminPage = () => {
   );
 
   // Données des modules de formation
-  const modules = useMemo(
-    () => [
-      {
-        title: 'Les Bases de React',
-        description: 'Apprends les fondamentaux de React pour créer des interfaces utilisateur modernes',
-        level: 'Débutant',
-        duration: '4h',
-        category: 'Frontend',
-        programme: 'Programme Développement Frontend',
-      },
-      {
-        title: 'JavaScript Avancé',
-        description: 'Maîtrise les concepts avancés de JavaScript pour devenir un développeur expert',
-        level: 'Avancé',
-        duration: '6h',
-        category: 'Programmation',
-        programme: 'Programme Développement Frontend',
-      },
-      {
-        title: 'Maîtrise CSS',
-        description: 'Deviens expert en CSS et animations pour créer des interfaces époustouflantes',
-        level: 'Intermédiaire',
-        duration: '5h',
-        category: 'Frontend',
-        programme: 'Programme Développement Frontend',
-      },
-    ],
-    [],
-  );
+  type Module = {
+    title: string;
+    description: string;
+    level: string;
+    duration: string;
+    category: string;
+    programme: string;
+    prerequisites?: string[];
+    objectives?: string[];
+  };
+
+  const [modules, setModules] = useState<Module[]>([
+    {
+      title: 'Les Bases de React',
+      description: 'Apprends les fondamentaux de React pour créer des interfaces utilisateur modernes',
+      level: 'Débutant',
+      duration: '4h',
+      category: 'Frontend',
+      programme: 'Programme Développement Frontend',
+    },
+    {
+      title: 'JavaScript Avancé',
+      description: 'Maîtrise les concepts avancés de JavaScript pour devenir un développeur expert',
+      level: 'Avancé',
+      duration: '6h',
+      category: 'Programmation',
+      programme: 'Programme Développement Frontend',
+    },
+    {
+      title: 'Maîtrise CSS',
+      description: 'Deviens expert en CSS et animations pour créer des interfaces époustouflantes',
+      level: 'Intermédiaire',
+      duration: '5h',
+      category: 'Frontend',
+      programme: 'Programme Développement Frontend',
+    },
+  ]);
 
   // Données des badges de reconnaissance
   const badges = useMemo(
@@ -299,38 +371,151 @@ const AdminPage = () => {
   );
 
   // Données des apprenants
-  const learners = useMemo(
-    () => [
-      {
-        name: 'Marie Dubois',
-        handle: '@mariedubois',
-        email: 'marie.dubois@laruche.fr',
-        programme: 'Parcours UX Design',
-        modulesCompleted: 4,
-        totalModules: 6,
-        lastActivity: 'Il y a 2 heures',
-      },
-      {
-        name: 'Thomas Lévy',
-        handle: '@thomaslevy',
-        email: 'thomas.levy@laruche.fr',
-        programme: 'Programme Développement Backend',
-        modulesCompleted: 3,
-        totalModules: 5,
-        lastActivity: 'Hier',
-      },
-      {
-        name: 'Emma Bernard',
-        handle: '@emma.bernard',
-        email: 'emma.bernard@laruche.fr',
-        programme: 'Programme Data Analyst',
-        modulesCompleted: 5,
-        totalModules: 7,
-        lastActivity: 'Il y a 3 jours',
-      },
-    ],
-    [],
-  );
+  const [learners, setLearners] = useState<Learner[]>([
+    {
+      name: 'Marie Dubois',
+      handle: '@mariedubois',
+      email: 'marie.dubois@laruche.fr',
+      programme: 'Parcours UX Design',
+      modulesCompleted: 4,
+      totalModules: 6,
+      lastActivity: 'Il y a 2 heures',
+    },
+    {
+      name: 'Thomas Lévy',
+      handle: '@thomaslevy',
+      email: 'thomas.levy@laruche.fr',
+      programme: 'Programme Développement Backend',
+      modulesCompleted: 3,
+      totalModules: 5,
+      lastActivity: 'Hier',
+    },
+    {
+      name: 'Emma Bernard',
+      handle: '@emma.bernard',
+      email: 'emma.bernard@laruche.fr',
+      programme: 'Programme Data Analyst',
+      modulesCompleted: 5,
+      totalModules: 7,
+      lastActivity: 'Il y a 3 jours',
+    },
+  ]);
+
+  const availableModules = useMemo(() => modules.map((module) => module.title), [modules]);
+
+  const handleModuleChange = (field: keyof typeof newModule, value: string) => {
+    setNewModule((prev) => ({
+      ...prev,
+      [field]: value,
+    }));
+  };
+
+  const resetModuleForm = () => {
+    setNewModule({
+      title: '',
+      programme: 'Aucun programme',
+      description: '',
+      category: '',
+      difficulty: 'Débutant',
+      duration: '',
+      prerequisites: '',
+      objectives: '',
+    });
+  };
+
+  const handleAddModule = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!newModule.title.trim()) {
+      return;
+    }
+
+    const prerequisites = newModule.prerequisites
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean);
+
+    const objectives = newModule.objectives
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean);
+
+    const moduleToAdd: Module = {
+      title: newModule.title.trim(),
+      programme: newModule.programme || 'Aucun programme',
+      description: newModule.description.trim() || 'Aucune description fournie pour le moment.',
+      level: newModule.difficulty || 'Débutant',
+      duration: newModule.duration ? `${newModule.duration}h` : '0h',
+      category: newModule.category.trim() || 'Non classé',
+      prerequisites: prerequisites.length ? prerequisites : undefined,
+      objectives: objectives.length ? objectives : undefined,
+    };
+
+    setModules((prev) => [moduleToAdd, ...prev]);
+    setIsAddModuleModalOpen(false);
+    resetModuleForm();
+  };
+
+  const closeModuleModal = () => {
+    setIsAddModuleModalOpen(false);
+    resetModuleForm();
+  };
+
+  const handleInputChange = (field: 'firstName' | 'lastName' | 'email', value: string) => {
+    setNewLearner((prev) => ({
+      ...prev,
+      [field]: value,
+    }));
+  };
+
+  const toggleModuleSelection = (moduleTitle: string) => {
+    setNewLearner((prev) => {
+      const isSelected = prev.modules.includes(moduleTitle);
+      return {
+        ...prev,
+        modules: isSelected
+          ? prev.modules.filter((title) => title !== moduleTitle)
+          : [...prev.modules, moduleTitle],
+      };
+    });
+  };
+
+  const resetLearnerForm = () => {
+    setNewLearner({ firstName: '', lastName: '', email: '', modules: [] });
+  };
+
+  const handleAddLearner = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!newLearner.firstName || !newLearner.lastName || !newLearner.email) {
+      return;
+    }
+
+    const name = `${newLearner.firstName.trim()} ${newLearner.lastName.trim()}`.trim();
+    const handle = `@${`${newLearner.firstName}${newLearner.lastName}`
+      .normalize('NFD')
+      .replace(/\p{Diacritic}/gu, '')
+      .replace(/[^a-zA-Z]/g, '')
+      .toLowerCase()}`;
+
+    const learnerToAdd: Learner = {
+      name,
+      handle,
+      email: newLearner.email.trim(),
+      modulesToEnroll: newLearner.modules,
+      modulesCompleted: 0,
+      totalModules: newLearner.modules.length,
+      lastActivity: "En attente d'inscription",
+    };
+
+    setLearners((prev) => [learnerToAdd, ...prev]);
+    setIsAddLearnerModalOpen(false);
+    resetLearnerForm();
+  };
+
+  const closeModal = () => {
+    setIsAddLearnerModalOpen(false);
+    resetLearnerForm();
+  };
 
   // Rendu du composant
   return (
@@ -386,7 +571,7 @@ const AdminPage = () => {
                     icon={action.icon}
                     label={action.label}
                     description={action.description}
-                    onClick={() => console.log(`${action.label} clicked`)}
+                    onClick={action.onClick}
                   />
                 ))}
               </div>
@@ -404,6 +589,7 @@ const AdminPage = () => {
               </div>
               <button
                 type="button"
+                onClick={() => setIsAddModuleModalOpen(true)}
                 className="flex items-center gap-2 rounded-full bg-primary px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-primary-dark"
               >
                 <span className="text-base text-white">
@@ -468,6 +654,7 @@ const AdminPage = () => {
               </div>
               <button
                 type="button"
+                onClick={() => setIsAddModuleModalOpen(true)}
                 className="flex items-center gap-2 rounded-full bg-primary px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-primary-dark"
               >
                 <span className="text-base text-white">
@@ -494,6 +681,26 @@ const AdminPage = () => {
                       <span className="rounded-full bg-slate-100 px-3 py-1 font-medium text-slate-600">{module.category}</span>
                       <span className="rounded-full bg-slate-100 px-3 py-1 font-medium text-slate-600">{module.programme}</span>
                     </div>
+                    {module.prerequisites?.length ? (
+                      <div className="mt-4">
+                        <h4 className="text-sm font-semibold text-slate-900">Prérequis</h4>
+                        <ul className="mt-2 list-inside list-disc text-sm text-slate-600">
+                          {module.prerequisites.map((item) => (
+                            <li key={item}>{item}</li>
+                          ))}
+                        </ul>
+                      </div>
+                    ) : null}
+                    {module.objectives?.length ? (
+                      <div className="mt-4">
+                        <h4 className="text-sm font-semibold text-slate-900">Objectifs pédagogiques</h4>
+                        <ul className="mt-2 list-inside list-disc text-sm text-slate-600">
+                          {module.objectives.map((item) => (
+                            <li key={item}>{item}</li>
+                          ))}
+                        </ul>
+                      </div>
+                    ) : null}
                   </div>
                   <div className="flex flex-col items-stretch gap-2 md:flex-row md:items-center">
                     <button
@@ -521,6 +728,157 @@ const AdminPage = () => {
           </section>
         ) : null}
 
+        {isAddModuleModalOpen ? (
+          <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/40 p-4 backdrop-blur-sm">
+            <div className="w-full max-w-2xl rounded-3xl bg-white p-6 shadow-xl">
+              <div className="flex items-start justify-between">
+                <div>
+                  <h3 className="text-xl font-semibold text-slate-900">Créer un Module</h3>
+                  <p className="mt-1 text-sm text-slate-500">
+                    Renseignez les informations pédagogiques pour ajouter un nouveau module au catalogue.
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={closeModuleModal}
+                  className="rounded-full p-2 text-slate-400 transition hover:bg-slate-100 hover:text-slate-600"
+                  aria-label="Fermer la fenêtre de création de module"
+                >
+                  <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path
+                      d="M15.8334 4.1665L4.16669 15.8332"
+                      stroke="currentColor"
+                      strokeWidth="1.6"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                    <path
+                      d="M4.16669 4.1665L15.8334 15.8332"
+                      stroke="currentColor"
+                      strokeWidth="1.6"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
+                </button>
+              </div>
+
+              <form onSubmit={handleAddModule} className="mt-6 flex flex-col gap-5">
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <label className="flex flex-col gap-1 text-sm font-medium text-slate-700">
+                    Titre *
+                    <input
+                      type="text"
+                      value={newModule.title}
+                      onChange={(event) => handleModuleChange('title', event.target.value)}
+                      className="rounded-2xl border border-slate-200 px-4 py-2.5 text-sm text-slate-900 shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
+                      placeholder="Ex. Interface utilisateur avancée"
+                      required
+                    />
+                  </label>
+                  <label className="flex flex-col gap-1 text-sm font-medium text-slate-700">
+                    Programme
+                    <select
+                      value={newModule.programme}
+                      onChange={(event) => handleModuleChange('programme', event.target.value)}
+                      className="rounded-2xl border border-slate-200 px-4 py-2.5 text-sm text-slate-900 shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
+                    >
+                      <option value="Aucun programme">Aucun programme</option>
+                      <option value="Programme Développement Frontend">Programme Développement Frontend</option>
+                      <option value="Programme Développement Backend">Programme Développement Backend</option>
+                      <option value="Programme Data Analyst">Programme Data Analyst</option>
+                    </select>
+                  </label>
+                </div>
+
+                <label className="flex flex-col gap-1 text-sm font-medium text-slate-700">
+                  Description
+                  <textarea
+                    value={newModule.description}
+                    onChange={(event) => handleModuleChange('description', event.target.value)}
+                    className="min-h-[96px] rounded-2xl border border-slate-200 px-4 py-2.5 text-sm text-slate-900 shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
+                    placeholder="Décrivez les objectifs généraux du module"
+                  />
+                </label>
+
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <label className="flex flex-col gap-1 text-sm font-medium text-slate-700">
+                    Catégorie
+                    <input
+                      type="text"
+                      value={newModule.category}
+                      onChange={(event) => handleModuleChange('category', event.target.value)}
+                      className="rounded-2xl border border-slate-200 px-4 py-2.5 text-sm text-slate-900 shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
+                      placeholder="Ex. Frontend, Backend"
+                    />
+                  </label>
+                  <label className="flex flex-col gap-1 text-sm font-medium text-slate-700">
+                    Difficulté
+                    <select
+                      value={newModule.difficulty}
+                      onChange={(event) => handleModuleChange('difficulty', event.target.value)}
+                      className="rounded-2xl border border-slate-200 px-4 py-2.5 text-sm text-slate-900 shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
+                    >
+                      <option value="Débutant">Débutant</option>
+                      <option value="Intermédiaire">Intermédiaire</option>
+                      <option value="Avancé">Avancé</option>
+                    </select>
+                  </label>
+                </div>
+
+                <label className="flex flex-col gap-1 text-sm font-medium text-slate-700">
+                  Durée (heures)
+                  <input
+                    type="number"
+                    min="0"
+                    value={newModule.duration}
+                    onChange={(event) => handleModuleChange('duration', event.target.value)}
+                    className="rounded-2xl border border-slate-200 px-4 py-2.5 text-sm text-slate-900 shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
+                    placeholder="0"
+                  />
+                </label>
+
+                <label className="flex flex-col gap-1 text-sm font-medium text-slate-700">
+                  Prérequis (un par ligne)
+                  <textarea
+                    value={newModule.prerequisites}
+                    onChange={(event) => handleModuleChange('prerequisites', event.target.value)}
+                    className="min-h-[96px] rounded-2xl border border-slate-200 px-4 py-2.5 text-sm text-slate-900 shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
+                    placeholder={'Connaissances HTML de base\nNotions de CSS'}
+                  />
+                </label>
+
+                <label className="flex flex-col gap-1 text-sm font-medium text-slate-700">
+                  Objectifs pédagogiques (un par ligne)
+                  <textarea
+                    value={newModule.objectives}
+                    onChange={(event) => handleModuleChange('objectives', event.target.value)}
+                    className="min-h-[96px] rounded-2xl border border-slate-200 px-4 py-2.5 text-sm text-slate-900 shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
+                    placeholder={'Maîtriser les composants React\nComprendre les hooks'}
+                  />
+                </label>
+
+                <div className="flex items-center justify-end gap-3">
+                  <button
+                    type="button"
+                    onClick={closeModuleModal}
+                    className="rounded-full border border-slate-200 px-5 py-2 text-sm font-semibold text-slate-600 transition hover:border-slate-300 hover:text-slate-700"
+                  >
+                    Annuler
+                  </button>
+                  <button
+                    type="submit"
+                    className="rounded-full bg-primary px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-primary-dark disabled:cursor-not-allowed disabled:bg-slate-300"
+                    disabled={!newModule.title.trim()}
+                  >
+                    Créer le Module
+                  </button>
+                </div>
+              </form>
+            </div>
+          </div>
+        ) : null}
+
         {/* Contenu de l'onglet Apprenants */}
         {activeTab === 'Apprenants' ? (
           <section className="flex flex-col gap-6">
@@ -533,6 +891,7 @@ const AdminPage = () => {
               </div>
               <button
                 type="button"
+                onClick={() => setIsAddLearnerModalOpen(true)}
                 className="flex items-center gap-2 rounded-full bg-primary px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-primary-dark"
               >
                 <span className="text-base text-white">
@@ -563,11 +922,25 @@ const AdminPage = () => {
                       </div>
                       <p className="text-sm text-slate-500">{learner.email}</p>
                       <div className="mt-3 flex flex-wrap items-center gap-2 text-xs text-slate-500 sm:text-sm">
-                        <span className="rounded-full bg-slate-100 px-3 py-1 font-medium text-slate-600">{learner.programme}</span>
-                        <span className="rounded-full bg-slate-100 px-3 py-1 font-medium text-slate-600">
-                          {learner.modulesCompleted} / {learner.totalModules} modules
-                        </span>
-                        <span className="rounded-full bg-slate-100 px-3 py-1 font-medium text-slate-600">{learner.lastActivity}</span>
+                        {learner.programme ? (
+                          <span className="rounded-full bg-slate-100 px-3 py-1 font-medium text-slate-600">{learner.programme}</span>
+                        ) : null}
+                        {typeof learner.modulesCompleted === 'number' && typeof learner.totalModules === 'number' ? (
+                          <span className="rounded-full bg-slate-100 px-3 py-1 font-medium text-slate-600">
+                            {learner.modulesCompleted} / {learner.totalModules} modules
+                          </span>
+                        ) : null}
+                        {learner.modulesToEnroll?.length ? (
+                          <span className="rounded-full bg-primary-light/60 px-3 py-1 font-medium text-primary">Modules à inscrire</span>
+                        ) : null}
+                        {learner.modulesToEnroll?.map((module) => (
+                          <span key={module} className="rounded-full bg-slate-100 px-3 py-1 font-medium text-slate-600">
+                            {module}
+                          </span>
+                        ))}
+                        {learner.lastActivity ? (
+                          <span className="rounded-full bg-slate-100 px-3 py-1 font-medium text-slate-600">{learner.lastActivity}</span>
+                        ) : null}
                       </div>
                     </div>
                   </div>
@@ -595,6 +968,120 @@ const AdminPage = () => {
               ))}
             </div>
           </section>
+        ) : null}
+
+        {isAddLearnerModalOpen ? (
+          <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/40 p-4 backdrop-blur-sm">
+            <div className="w-full max-w-lg rounded-3xl bg-white p-6 shadow-xl">
+              <div className="flex items-start justify-between">
+                <div>
+                  <h3 className="text-xl font-semibold text-slate-900">Ajouter un Apprenant</h3>
+                  <p className="mt-1 text-sm text-slate-500">
+                    Renseignez les informations de l'apprenant et sélectionnez les modules à inscrire.
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={closeModal}
+                  className="rounded-full p-2 text-slate-400 transition hover:bg-slate-100 hover:text-slate-600"
+                  aria-label="Fermer la fenêtre d'ajout"
+                >
+                  <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path
+                      d="M15.8334 4.1665L4.16669 15.8332"
+                      stroke="currentColor"
+                      strokeWidth="1.6"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                    <path
+                      d="M4.16669 4.1665L15.8334 15.8332"
+                      stroke="currentColor"
+                      strokeWidth="1.6"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
+                </button>
+              </div>
+
+              <form onSubmit={handleAddLearner} className="mt-6 flex flex-col gap-5">
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <label className="flex flex-col gap-1 text-sm font-medium text-slate-700">
+                    Prénom *
+                    <input
+                      type="text"
+                      value={newLearner.firstName}
+                      onChange={(event) => handleInputChange('firstName', event.target.value)}
+                      className="rounded-2xl border border-slate-200 px-4 py-2.5 text-sm text-slate-900 shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
+                      placeholder="Ex. Marie"
+                      required
+                    />
+                  </label>
+                  <label className="flex flex-col gap-1 text-sm font-medium text-slate-700">
+                    Nom *
+                    <input
+                      type="text"
+                      value={newLearner.lastName}
+                      onChange={(event) => handleInputChange('lastName', event.target.value)}
+                      className="rounded-2xl border border-slate-200 px-4 py-2.5 text-sm text-slate-900 shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
+                      placeholder="Ex. Dubois"
+                      required
+                    />
+                  </label>
+                </div>
+                <label className="flex flex-col gap-1 text-sm font-medium text-slate-700">
+                  Email *
+                  <input
+                    type="email"
+                    value={newLearner.email}
+                    onChange={(event) => handleInputChange('email', event.target.value)}
+                    className="rounded-2xl border border-slate-200 px-4 py-2.5 text-sm text-slate-900 shadow-sm focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
+                    placeholder="exemple@laruche.fr"
+                    required
+                  />
+                </label>
+
+                <fieldset className="flex flex-col gap-3 rounded-2xl border border-slate-200 p-4">
+                  <legend className="px-2 text-sm font-semibold text-slate-900">Modules à inscrire</legend>
+                  {availableModules.map((moduleTitle) => {
+                    const isChecked = newLearner.modules.includes(moduleTitle);
+                    return (
+                      <label key={moduleTitle} className="flex items-center gap-3 text-sm text-slate-700">
+                        <input
+                          type="checkbox"
+                          checked={isChecked}
+                          onChange={() => toggleModuleSelection(moduleTitle)}
+                          className="h-4 w-4 rounded border-slate-300 text-primary focus:ring-primary"
+                        />
+                        <span>{moduleTitle}</span>
+                      </label>
+                    );
+                  })}
+                  {!availableModules.length ? (
+                    <p className="text-sm text-slate-500">Aucun module disponible pour le moment.</p>
+                  ) : null}
+                </fieldset>
+
+                <div className="flex items-center justify-end gap-3">
+                  <button
+                    type="button"
+                    onClick={closeModal}
+                    className="rounded-full border border-slate-200 px-5 py-2 text-sm font-semibold text-slate-600 transition hover:border-slate-300 hover:text-slate-700"
+                  >
+                    Annuler
+                  </button>
+                  <button
+                    type="submit"
+                    className="rounded-full bg-primary px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-primary-dark disabled:cursor-not-allowed disabled:bg-slate-300"
+                    disabled={!newLearner.firstName || !newLearner.lastName || !newLearner.email}
+                  >
+                    Ajouter l'Apprenant
+                  </button>
+                </div>
+              </form>
+            </div>
+          </div>
         ) : null}
 
         {/* Contenu de l'onglet Badges */}


### PR DESCRIPTION
## Summary
- add stateful module catalog management to persist newly created modules in the admin dashboard
- implement the "Créer un Module" modal with required fields, dropdowns, and textarea capture for prerequisites and objectives
- hook the Modules tab and quick action button to open the modal and surface richer module details in the catalog cards

## Testing
- npm run build *(fails: existing TypeScript config is missing modern lib/Node typings and rollup module resolution support)*

------
https://chatgpt.com/codex/tasks/task_b_68d7ea7966608330bf65fd73747274b9